### PR TITLE
v0.8.0 - Guest Comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 
 The aim of this project is to promote the Steem ecosystem by breaking the comments system out of the walls of Steem based apps.
 
-## Finally comments - V0.7.1
-An embededable version of steem (steemit/utopian) comments with comment and vote functionality
+## Finally comments - V0.8.0
+A embedable comments system built on the STEEM blockchain.
 
 ### How It Works
 [Please visit the site for more detaails](http://finallycomments.com)
 
-Finally is an evolution of Steemcomments.js and at its core uses the Steem blockchain to provide posting and curation rewards to its users. Similar to other popular plug and play comment systems Finally requires only a single html tag while our javascript library & backend system take care of the rest.
+Finally is a comments system for blogs and website built on top of the STEEM blockchain. Similar to other popular plug and play comment systems Finally requires only a single html tag while our javascript library & backend system take care of the rest. The STEEM blockchain to provides posting and curation rewards to its users unlike any other comments system.
 
 Login to the dashboard at [http://finallycomments.com](http://finallycomments.com/auth/dashboard). to generate code for any Steemit(or any other STEEM based platform) post with one click.
 ```
@@ -20,8 +20,6 @@ Login to the dashboard at [http://finallycomments.com](http://finallycomments.co
 ![](http://i66.tinypic.com/5ozia8.jpg)
 
 Finally uses Steemconnect authentication to allow users to post comments and upvotes directly from anywhere Finally is embeded. Once authenticated with Finally users will not have to log in again when visiting other sites that also use Finally.
-
-*Currently Finally only supports content already posted to the Steem network. Sites including Steemit, Busy or Utopian. Support for more sites (dmania/dsound/dtube/dlive) will be added shortly and in the comming weeks support for content outside of the Steem blockchain will be enabled.*
 
 ### Development Setup
 You'll need to create an account on steemconnect.com to work on this project (current cost 3 STEEM). Use the details within the finallycomments app. Make sure the redirect url matches.
@@ -38,6 +36,9 @@ NODE_CLIENT_ID="newproject.app" NODE_REDIRECT_URI="localhost:3000/auth/" NODE_SE
 - stats for threads/account
 - auto hide posts from rep less than X
 - edit/delete/flag comments
+- Themes
+- How To Guides
+- Beneficiaries
+- User Profiles
 - moderate comments (completely remove with flag from author)
 - wordpress plugin
-- non logged in user comments (not expected for some time)

--- a/models/guest-comment.js
+++ b/models/guest-comment.js
@@ -8,3 +8,15 @@ module.exports.insert = async (comment) => {
     })
   });
 }
+
+module.exports.find = async (permlink) => {
+  return new Promise((resolve, reject) => {
+    db.get().db('finally').collection('guest-comments').find({'postPermlink': permlink}).toArray( (error, result) => {
+      if(error) { reject({ error: error }) }
+      else {
+        console.log('result from custom search: ', result)
+        resolve(result)
+      }
+    });
+  });
+}

--- a/models/guest-comment.js
+++ b/models/guest-comment.js
@@ -11,7 +11,7 @@ module.exports.insert = async (comment) => {
 
 module.exports.find = async (permlink) => {
   return new Promise((resolve, reject) => {
-    db.get().db('finally').collection('guest-comments').find({'postPermlink': permlink}).toArray( (error, result) => {
+    db.get().db('finally').collection('guest-comments').find({'root_comment': permlink}).toArray( (error, result) => {
       if(error) { reject({ error: error }) }
       else {
         console.log('result from custom search: ', result)

--- a/models/guest-comment.js
+++ b/models/guest-comment.js
@@ -1,0 +1,10 @@
+let db = require('../modules/db')
+
+module.exports.insert = async (comment) => {
+  return new Promise((resolve, reject) => {
+    db.get().db('finally').collection('guest-comments').insertOne(comment, (error, response) => {
+      if(error || response == null) { reject({ error }) }
+      else { resolve({ error: false, comment}) }
+    })
+  });
+}

--- a/models/guest-reply-comment.js
+++ b/models/guest-reply-comment.js
@@ -1,0 +1,22 @@
+let db = require('../modules/db')
+
+module.exports.insert = async (comment) => {
+  return new Promise((resolve, reject) => {
+    db.get().db('finally').collection('guest-reply-comments').insertOne(comment, (error, response) => {
+      if(error || response == null) { reject({ error }) }
+      else { resolve({ error: false, comment}) }
+    })
+  });
+}
+
+module.exports.find = async (permlink) => {
+  return new Promise((resolve, reject) => {
+    db.get().db('finally').collection('guest-reply-comments').find({'root_comment': permlink}).toArray( (error, result) => {
+      if(error) { reject({ error: error }) }
+      else {
+        console.log('result from custom search: ', result)
+        resolve(result)
+      }
+    });
+  });
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "finally-comments",
-  "version": "0.7.1",
+  "version": "0.8.1",
   "private": true,
   "scripts": {
     "start": "node ./bin/www"

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -337,6 +337,23 @@ a.sc-settings__logout {
   font-size: 16px;
 }
 
+
+.sc-guest-comment__btn {
+  display: inline-block;
+  margin: 0 10px 10px 0;
+  cursor: pointer;
+  background: #dfdbdb;
+  border-radius: 2px;
+  color: #303030;
+  box-shadow: 0 0 15px rgba(0,0,0,0.15);
+  padding: 5px 10px;
+  text-decoration: none;
+}
+a.sc-comment__btn:hover {
+  color: #fff;
+  text-decoration: none;
+  background-color: #16191f;
+}
 .sc-comment__btn {
   display: inline-block;
   margin: 0 10px 10px 0;

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -77,14 +77,22 @@ a {
   display: none;
 }
 
+.sc-input {
+  padding: 6px 10px;
+  border-radius: 3px;
+  text-decoration: none;
+  margin-bottom: 10px;
+  margin-right: 7px;
+  border: solid 1px #ccc;
+  box-shadow: 0 0 15px rgba(0,0,0,0.15)
+}
 .sc-login {
-  float: right;
   background-color: #6eafff;
   padding: 5px 10px;
   border-radius: 3px;
   color: #fff;
   text-decoration: none;
-  margin-bottom: 10px;
+  margin: 0 0 10px 5px;
 }
 .sc-login:hover {
   text-decoration: none;
@@ -93,6 +101,10 @@ a {
 
 .sc-login--true {
   display: none;
+}
+
+.sc-login--topbar {
+  float: right;
 }
 
 .sc-profile__image {
@@ -173,6 +185,7 @@ a.sc-settings__logout {
 }
 .sc-close {
   cursor: pointer;
+  float: right;
 }
 .sc-item {
   padding: 0 15px 10px;
@@ -349,8 +362,9 @@ a.sc-settings__logout {
   padding: 5px 10px;
   text-decoration: none;
 }
+
 a.sc-comment__btn:hover {
-  color: #fff;
+  color: #333;
   text-decoration: none;
   background-color: #16191f;
 }

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -185,7 +185,7 @@ a.sc-settings__logout {
 }
 .sc-close {
   cursor: pointer;
-  float: right;
+  /*float: right;*/
 }
 .sc-item {
   padding: 0 15px 10px;

--- a/public/js/thread.js
+++ b/public/js/thread.js
@@ -351,12 +351,7 @@ const steemComments = {
       $.post({
         url: `/guest-comment`,
         dataType: 'json',
-        data: {
-          parentAuthor: parentAuthor,
-          parentPermlink: parentPermlink,
-          message: message,
-          parentTitle: parentTitle
-        }
+        data: {parentAuthor, parentPermlink, message, parentTitle, mainPostPermlink: steemComments.PERMLINK }
       }, (response) => {
           console.log(response)
       })

--- a/public/js/thread.js
+++ b/public/js/thread.js
@@ -8,6 +8,7 @@ const steemComments = {
     ISAUTHENTICATED: $('.sc-section').data('auth'),
     USERACCOUNTS: [],
     OPTIONS: {},
+    upvoteIcon: '<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 50 50" width="18px" height="18px"><circle fill="transparent" stroke="#000000" stroke-width="3" strokemiterlimit="10" class="st0" cx="25" cy="25" r="23"/><line stroke="#000000" stroke-width="3" strokemiterlimit="10" class="st1" x1="13.6" y1="30.6" x2="26" y2="18.2"/><line stroke="#000000" stroke-width="3" strokemiterlimit="10" class="st2" x1="36.4" y1="30.6" x2="24" y2="18.2"/></svg>',
     authenticatedUser: () => {
       if (steemComments.ISAUTHENTICATED){
         return $('.sc-section').data('username');
@@ -208,14 +209,7 @@ const steemComments = {
       let authUrl = $('.sc-section').data('auth-url')
       let template = `
           <div class="sc-topbar sc-cf">
-            <span class="sc-topbar__upvote">
-            <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-            viewBox="0 0 50 50" width="22px" height="22px">
-            <circle fill="transparent" stroke="#000000" stroke-width="3" strokemiterlimit="10" class="st0" cx="25" cy="25" r="23"/>
-            <line stroke="#000000" stroke-width="3" strokemiterlimit="10" class="st1" x1="13.6" y1="30.6" x2="26" y2="18.2"/>
-            <line stroke="#000000" stroke-width="3" strokemiterlimit="10" class="st2" x1="36.4" y1="30.6" x2="24" y2="18.2"/>
-            </svg>
-            </span>
+            <span class="sc-topbar__upvote">${steemComments.upvoteIcon}</span>
             <span class="sc-topbar__reply">Reply</span>
 
             <span class="sc-topbar__count"> 00 Comments</span>
@@ -256,14 +250,7 @@ const steemComments = {
     addVoteTemplateAfter: (dest) => {
       $('.sc-vote').remove()
       let template = `<div class="sc-vote">
-      <span class="sc-vote__btn">
-      <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-      viewBox="0 0 50 50" width="30px" height="30px">
-      <circle fill="transparent" stroke="#000000" stroke-width="3" strokemiterlimit="10" class="st0" cx="25" cy="25" r="23"/>
-      <line stroke="#000000" stroke-width="3" strokemiterlimit="10" class="st1" x1="13.6" y1="30.6" x2="26" y2="18.2"/>
-      <line stroke="#000000" stroke-width="3" strokemiterlimit="10" class="st2" x1="36.4" y1="30.6" x2="24" y2="18.2"/>
-      </svg>
-      </span>
+      <span class="sc-vote__btn"><span class="sc-topbar__upvote">${steemComments.upvoteIcon}</span>
       <span class="sc-vote__value">50%</span>
       <input type="range" min="1" max="100" value="50" class="sc-vote__slider" id="myRange">
       <span class="sc-close sc-vote__close" >&#43;</span>
@@ -521,14 +508,7 @@ const steemComments = {
           </h4>
           <p class="sc-item__content">${ html }</p>
           <div class="sc-item__meta">
-          <span class="sc-item__upvote sc-item__upvote--voted-${voted}">
-          <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-          viewBox="0 0 50 50" width="18px" height="18px">
-          <circle fill="transparent" stroke="#000000" stroke-width="3" strokemiterlimit="10" class="st0" cx="25" cy="25" r="23"/>
-          <line stroke="#000000" stroke-width="3" strokemiterlimit="10" class="st1" x1="13.6" y1="30.6" x2="26" y2="18.2"/>
-          <line stroke="#000000" stroke-width="3" strokemiterlimit="10" class="st2" x1="36.4" y1="30.6" x2="24" y2="18.2"/>
-          </svg>
-          </span>
+          <span class="sc-item__upvote sc-item__upvote--voted-${voted}"><span class="sc-topbar__upvote">${steemComments.svgIcon}</span>
           <span class="sc-item__divider">|</span>
           <span class="sc-item__votecount">${post.votes} ${voteMessage} ${ steemComments.OPTIONS.values ? voteValue : ''}</span>
           <span class="sc-item__divider">|</span>
@@ -568,14 +548,7 @@ const steemComments = {
         </h4>
         <p class="sc-item__content">${ post.body }</p>
         <div class="sc-item__meta">
-        <span class="sc-item__upvote">
-        <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-        viewBox="0 0 50 50" width="18px" height="18px">
-        <circle fill="transparent" stroke="#000000" stroke-width="3" strokemiterlimit="10" class="st0" cx="25" cy="25" r="23"/>
-        <line stroke="#000000" stroke-width="3" strokemiterlimit="10" class="st1" x1="13.6" y1="30.6" x2="26" y2="18.2"/>
-        <line stroke="#000000" stroke-width="3" strokemiterlimit="10" class="st2" x1="36.4" y1="30.6" x2="24" y2="18.2"/>
-        </svg>
-        </span>
+        <span class="sc-item__upvote">${steemComments.upvoteIcon}</span>
         <span class="sc-item__divider">|</span>
         <span class="sc-item__votecount">0 votes</span>
         <span class="sc-item__divider">|</span>

--- a/public/js/thread.js
+++ b/public/js/thread.js
@@ -323,8 +323,12 @@ const steemComments = {
       })
     },
     appendSuccessfulComment: (response, parentDepth, parentElement, fromSteem) => {
-      console.log(response, parentDepth, parentElement)
-      let newComment = $(steemComments.singleCommentTemplate(response.data, parentDepth, fromSteem))
+      let newComment, guestReply = false, guest = false;
+      let commentdata = steemComments.processAjaxCommentData(response.data, fromSteem, parentDepth)
+      // let newComment =  $(steemComments.singleCommentTemplate(commentdata, parentDepth, fromSteem, steemComments.ISAUTHENTICATED)
+      if (!fromSteem && !steemComments.ISAUTHENTICATED) guest = true
+      if (!fromSteem && steemComments.ISAUTHENTICATED) guestReply = true
+      newComment = $(steemComments.createCommentTemplate(steemComments.USERACCOUNTS, commentdata, false, false, guest, guestReply))
       let inputArea = $('.sc-comment__container')
       inputArea.fadeOut(400, () => inputArea.remove())
       $(parentElement).append(newComment)
@@ -585,49 +589,22 @@ const steemComments = {
           </div>`
           return template;
         },
-      singleCommentTemplate: (data, parentDepth, fromSteem) => {
-        console.log('data: ',data)
-        var post = {}, metadata;
-        if (fromSteem) {
-          data = data.result.operations[0][1]
-          metadata = { profile_image: $('.sc-section').data('profileimage') }
-        } else {
-          data = data.result.comment
-          metadata = { profile_image: '/img/default-user.jpg' }
-        }
+      processAjaxCommentData: (data, fromSteem, parentDepth) => {
+          var post = {}, metadata;
+          if (fromSteem) {
+            data = data.result.operations[0][1]
+            metadata = { profile_image: $('.sc-section').data('profileimage') }
+          } else {
+            data = data.result.comment
+            metadata = { profile_image: '/img/default-user.jpg' }
+          }
+          post.permlink = data.permlink,
+          post.author = data.author,
+          post.title = data.title,
+          post.body = data.body,
+          post.depth = parentDepth + 1
 
-        post.permlink = data.permlink,
-        post.author = data.author,
-        post.title = data.title,
-        post.body = data.body,
-        post.depth = parentDepth + 1
-
-        var template = `
-        <div data-permlink="${post.permlink}"
-        data-author="${post.author}"
-        data-title="${post.title}"
-        data-post-depth="${post.depth}"
-
-        class="sc-item sc-cf sc-item__level-${post.depth} ${post.permlink}">
-        <div class="sc-item__left">
-        <img class="sc-item__image" src="${metadata.profile_image}" height="50px" width="50px">
-        </div>
-        <div class="sc-item__right">
-        <h4 class="sc-item__username">
-        <a class="sc-item__author-link" href="https://steemit.com/@${post.author}" target="_blank">@${post.author}</a>
-        <span class="sc-item__middot"> &middot; </span> <span class="sc-item__datetime"> ${ moment(post.created).fromNow() } </span>
-        </h4>
-        <p class="sc-item__content">${ post.body }</p>
-        <div class="sc-item__meta">
-        <span class="sc-item__upvote">${steemComments.upvoteIcon}</span>
-        <span class="sc-item__divider">|</span>
-        <span class="sc-item__votecount">0 votes</span>
-        <span class="sc-item__divider">|</span>
-        <span class="sc-item__reply">Reply</span>
-        </div>
-        </div>
-        </div>`
-        return template;
+          return post
       },
       notificationTemplate: (message) => {
         $('.sc-notification').remove()

--- a/public/js/thread.js
+++ b/public/js/thread.js
@@ -65,22 +65,15 @@ const steemComments = {
           })
 
           $('.sc-topbar__reply').on('click', () => {
-            if ( steemComments.ISAUTHENTICATED){
-              steemComments.addCommentTemplateAfter('.sc-section .sc-topbar__rule')
-            } else {
-              $('.sc-comments').prepend(steemComments.notificationTemplate('Please sign in to comment.'))
-            }
+            steemComments.addCommentTemplateAfter('.sc-section .sc-topbar__rule')
             $('.sc-vote').remove()
+            $('.sc-notification').remove()
           })
 
           $('.sc-section').on('click', '.sc-item__reply', (e) => {
-
-            $('.sc-notification').remove()
-            if ( steemComments.ISAUTHENTICATED){
               steemComments.addCommentTemplateAfter(e.currentTarget)
-            } else {
-              $(e.currentTarget).closest('.sc-item__right').append(steemComments.notificationTemplate('Please sign in to comment.'))
-            }
+              $('.sc-vote').remove()
+              $('.sc-notification').remove()
           })
 
           $('.sc-section').on('click', '.sc-item__upvote', (e) => {
@@ -116,15 +109,18 @@ const steemComments = {
 
           $('.sc-section').on('click', '.sc-comment__btn' , (e) => {
             e.preventDefault()
-            let parentElement = $(e.currentTarget).closest('.sc-item') || $('.sc-comments')
-
-            let topLevel = $(e.currentTarget).parent().parent().hasClass('sc-section') ? true : false
-            let message = $('.sc-comment__message').val()
-            let parentPermlink = topLevel ? steemComments.PERMLINK : parentElement.data('permlink')
-            let parentAuthor = topLevel ? steemComments.AUTHOR : parentElement.data('author')
-            let title = topLevel ? '@'+parentAuthor : parentElement.data('title')
-            let parentDepth = parentElement.data('post-depth')
-            steemComments.sendComment(parentElement, parentAuthor,parentPermlink, message, title, parentDepth)
+            if ( steemComments.ISAUTHENTICATED) {
+              let parentElement = $(e.currentTarget).closest('.sc-item') || $('.sc-comments')
+              let topLevel = $(e.currentTarget).parent().parent().hasClass('sc-section') ? true : false
+              let message = $('.sc-comment__message').val()
+              let parentPermlink = topLevel ? steemComments.PERMLINK : parentElement.data('permlink')
+              let parentAuthor = topLevel ? steemComments.AUTHOR : parentElement.data('author')
+              let title = topLevel ? '@'+parentAuthor : parentElement.data('title')
+              let parentDepth = parentElement.data('post-depth')
+              steemComments.sendComment(parentElement, parentAuthor,parentPermlink, message, title, parentDepth)
+            } else {
+              $(e.currentTarget).closest('.sc-comment__container').append(steemComments.notificationTemplate('Please sign in to comment.'))
+            }
           })
 
           $('.sc-section').on('click', '.sc-comment__close, .sc-vote__close', (e) => {
@@ -516,7 +512,7 @@ const steemComments = {
       notificationTemplate: (message) => {
         $('.sc-notification').remove()
         let template = `
-        <div class="sc-notification">${message}</>
+        <div class="sc-notification">${message}</div>
         `
         return template;
       },

--- a/routes/index.js
+++ b/routes/index.js
@@ -6,6 +6,7 @@ let { steem, getAccessFromRefresh } = require('../modules/steemconnect')
 const Thread = require('../models/thread')
 const Domain = require('../models/domain')
 const Token = require('../models/token')
+const GuestComment = require('../models/guest-comment')
 
 router.get('/', (req, res, next) =>  {
   res.render('index', {
@@ -84,20 +85,36 @@ router.post('/comment', util.isAuthorized, (req, res) => {
 });
 
 router.post('/guest-comment', (req, res) => {
-    let author = 'guest'
-    let permlink = req.body.parentPermlink + '-' + util.urlString(32)
-    let title = 'RE: ' + req.body.parentTitle
-    let body = req.body.message
-    let parentAuthor = req.body.parentAuthor
-    let parentPermlink = req.body.parentPermlink
+    let comment = {
+      postPermlink: req.body.mainPostPermlink,
+      parentPermlink: req.body.parentPermlink,
+      author: 'Guest',
+      permlink: req.body.parentPermlink + '-' + util.urlString(32),
+      title: 'RE: ' + req.body.parentTitle,
+      body: req.body.message,
+      parentAuthor: req.body.parentAuthor
+    }
+    console.log(comment)
 
+    GuestComment.insert(comment)
+      .then(res => {
+
+        console.log(res)
+        res.json({
+          name: 'author',
+          msg: 'Posted A Guest Comment',
+          res: 'res'
+        })
+
+      })
+      .catch(err => {
+        console.log(err)
+                res.json({ error: err })
+
+      })
     // store comment in database
     // need to store main finally thread/top permlink to associate comments
-    res.json({
-      name: author,
-      msg: 'Posted A Guest Comment',
-      res: 'res'
-    })
+
 
 });
 

--- a/routes/index.js
+++ b/routes/index.js
@@ -83,6 +83,25 @@ router.post('/comment', util.isAuthorized, (req, res) => {
     });
 });
 
+router.post('/guest-comment', (req, res) => {
+    let author = 'guest'
+    let permlink = req.body.parentPermlink + '-' + util.urlString(32)
+    let title = 'RE: ' + req.body.parentTitle
+    let body = req.body.message
+    let parentAuthor = req.body.parentAuthor
+    let parentPermlink = req.body.parentPermlink
+
+    // store comment in database
+    // need to store main finally thread/top permlink to associate comments
+    res.json({
+      name: author,
+      msg: 'Posted A Guest Comment',
+      res: 'res'
+    })
+
+});
+
+
 router.get('/api/thread/:username/:slug', cors(), async (req, res, next) => {
   let username = req.params.username
   let slug = req.params.slug

--- a/routes/index.js
+++ b/routes/index.js
@@ -79,7 +79,7 @@ router.post('/comment', util.isAuthorized, (req, res) => {
         res.json({
           name: author,
           msg: 'Posted To Steem Network',
-          res: steemResponse
+          data: steemResponse
         })
       }
     });
@@ -104,7 +104,7 @@ router.post('/guest-reply-comment', util.isAuthorized, (req, res) => {
 
     GuestReplyComment.insert(comment)
       .then(dbResponse => {
-        res.json({result : dbResponse})
+        res.json({ data: {result : dbResponse} })
       })
       .catch(err => res.json({ error: err }))
 });

--- a/routes/index.js
+++ b/routes/index.js
@@ -86,34 +86,25 @@ router.post('/comment', util.isAuthorized, (req, res) => {
 
 router.post('/guest-comment', (req, res) => {
     let comment = {
-      postPermlink: req.body.mainPostPermlink,
-      parentPermlink: req.body.parentPermlink,
-      author: 'Guest',
-      permlink: req.body.parentPermlink + '-' + util.urlString(32),
+      postid: util.urlString(32),
       title: 'RE: ' + req.body.parentTitle,
-      body: req.body.message,
-      parentAuthor: req.body.parentAuthor
+      author: req.body.author,
+      body: req.body.commentBody,
+      permlink: req.body.parentPermlink + '_' + util.urlString(32),
+      depth: req.body.depth,
+      root_comment: req.body.rootComment,
+      parent_permlink: req.body.parentPermlink,
+      created: new Date().toISOString(),
+      votes: 0,
+      voters: [],
+      value: 0
     }
-    console.log(comment)
 
     GuestComment.insert(comment)
-      .then(res => {
-
-        console.log(res)
-        res.json({
-          name: 'author',
-          msg: 'Posted A Guest Comment',
-          res: 'res'
-        })
-
+      .then(dbResponse => {
+        res.json({result : dbResponse})
       })
-      .catch(err => {
-        console.log(err)
-                res.json({ error: err })
-
-      })
-    // store comment in database
-    // need to store main finally thread/top permlink to associate comments
+      .catch(err => res.json({ error: err }))
 });
 
 

--- a/routes/index.js
+++ b/routes/index.js
@@ -7,6 +7,7 @@ const Thread = require('../models/thread')
 const Domain = require('../models/domain')
 const Token = require('../models/token')
 const GuestComment = require('../models/guest-comment')
+const GuestReplyComment = require('../models/guest-reply-comment')
 
 router.get('/', (req, res, next) =>  {
   res.render('index', {
@@ -84,6 +85,30 @@ router.post('/comment', util.isAuthorized, (req, res) => {
     });
 });
 
+router.post('/guest-reply-comment', util.isAuthorized, (req, res) => {
+    steem.setAccessToken(req.session.access_token);
+    let comment = {
+      postid: util.urlString(32),
+      title: 'RE: ' + req.body.parentTitle,
+      author: req.session.steemconnect.name,
+      body: req.body.commentBody,
+      permlink: req.body.parentPermlink + '_' + util.urlString(32),
+      depth: req.body.depth,
+      root_comment: req.body.rootComment,
+      parent_permlink: req.body.parentPermlink,
+      created: new Date().toISOString(),
+      votes: 0,
+      voters: [],
+      value: 0
+    }
+
+    GuestReplyComment.insert(comment)
+      .then(dbResponse => {
+        res.json({result : dbResponse})
+      })
+      .catch(err => res.json({ error: err }))
+});
+
 router.post('/guest-comment', (req, res) => {
     let comment = {
       postid: util.urlString(32),
@@ -113,6 +138,13 @@ router.post('/guest-comments', async (req, res) => {
     let guestComments = await GuestComment.find(permlink)
     console.log('after db request: ', guestComments)
     res.json({guestComments})
+});
+
+router.post('/guest-reply-comments', async (req, res) => {
+    let permlink = req.body.permlink
+    let guestReplyComments = await GuestReplyComment.find(permlink)
+    console.log('after db request: ', guestReplyComments)
+    res.json({guestReplyComments})
 });
 
 

--- a/routes/index.js
+++ b/routes/index.js
@@ -127,11 +127,10 @@ router.post('/guest-comment', (req, res) => {
 
     GuestComment.insert(comment)
       .then(dbResponse => {
-        res.json({result : dbResponse})
+        res.json({ data: {result : dbResponse} })
       })
       .catch(err => res.json({ error: err }))
 });
-
 
 router.post('/guest-comments', async (req, res) => {
     let permlink = req.body.permlink

--- a/routes/index.js
+++ b/routes/index.js
@@ -114,8 +114,14 @@ router.post('/guest-comment', (req, res) => {
       })
     // store comment in database
     // need to store main finally thread/top permlink to associate comments
+});
 
 
+router.post('/guest-comments', async (req, res) => {
+    let permlink = req.body.permlink
+    let guestComments = await GuestComment.find(permlink)
+    console.log('after db request: ', guestComments)
+    res.json({guestComments})
 });
 
 


### PR DESCRIPTION
This PR adds the Guest Commenting functionality to Finally Comments. 

Previously a user would need to sign in before being able to interact with the comments thread. Currently the wait time for a Steem signup can be up to 1-2weeks, this is unacceptable for a user who wants to just leave a quick comment on a blog post. 

The guest comment allows a quick comment without needing auth. As these comments are not posted to the steem blockchain (the have no STEEM user associated) they are stored in a database. Incorporating steem/non-steem comments is a little tricky and means that replies to a guest comment from an authorised user still can not be posted to the blockchain (they will have no parent or context on the root post). 

NEW
- Guest Posting  - UI/Routes/AJAX/Models/Database
- Replying to Guest - ^

<img width="911" alt="guest" src="https://user-images.githubusercontent.com/34964560/39700074-c079df84-51f3-11e8-8675-45e612e9b30d.png">

<img width="912" alt="reply" src="https://user-images.githubusercontent.com/34964560/39700250-7681f618-51f4-11e8-97fe-02d49ff554a5.png">


Updated
- I was able to refactor parts of the comment template code so all actions STEEM, NON-STEEM and REPLY-TO-NON-STEEM can all use the same comment template function. In general there is still some work to do in documenting and refactoring to improve maintainability.  



