### PR TITLE
fix - check thread type and find correct root author

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 The aim of this project is to promote the Steem ecosystem by breaking the comments system out of the walls of Steem based apps.
 
-## Finally comments - V0.9.0
+## Finally comments - V0.9.1
 A embedable comments system built on the STEEM blockchain.
 
 ### How It Works

--- a/controllers/moderation.js
+++ b/controllers/moderation.js
@@ -10,9 +10,10 @@ module.exports.checkRequest = async (req, res) => {
   let author = req.body.commentAuthor
   let isGuestComment =  JSON.parse(req.body.isGuestComment)
   let isGuestReplyComment = JSON.parse(req.body.isGuestReplyComment)
+  let rootPostPath = req.body.rootPostPath
   let moderationType = req.body.moderationType
 
-  let commentDetails = await util.findRootCommentDetails(isGuestComment, isGuestReplyComment, permlink, author, category)
+  let commentDetails = await util.findRootCommentDetails(isGuestComment, isGuestReplyComment, permlink, rootPostPath)
   if (authenticatedUser !== commentDetails.rootAuthor ) return res.json({status: 'fail', error: 'Not Thread Owner'})
 
   if(moderationType === 'delete'){

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "finally-comments",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "private": true,
   "scripts": {
     "start": "node ./bin/www"

--- a/public/js/thread.js
+++ b/public/js/thread.js
@@ -492,6 +492,7 @@ const f = {
           commentAuthor: commentData.author,
           commentCategory: commentData.category,
           commentPermlink: commentData.permlink,
+          rootPostPath: `/${f.CATEGORY}/@${f.AUTHOR}/${f.PERMLINK}`,
           isGuestComment: commentData.guest,
           isGuestReplyComment: commentData.guestReply }
       })


### PR DESCRIPTION
hotfix for root author issue. 

Was passing the current comment path (of the item to be moderated) to the backend but also need a path of the current thread route to calc the route author on custom threads.