### PR TITLE
fix - missing user details for new commenter ajax success comment

### DIFF
--- a/public/js/thread.js
+++ b/public/js/thread.js
@@ -349,11 +349,15 @@ const f = {
         }
       })
     },
-    appendSuccessfulComment: (response, parentDepth, parentElement, fromSteem) => {
+    appendSuccessfulComment: async (response, parentDepth, parentElement, fromSteem) => {
       let newComment, guestReply = false, guest = false;
       let commentdata = f.processAjaxCommentData(response.data, fromSteem, parentDepth)
       if (!fromSteem && !f.ISAUTHENTICATED) guest = true
       if (!fromSteem && f.ISAUTHENTICATED) guestReply = true
+      if(f.ISAUTHENTICATED){
+        let accountData = await steem.api.getAccountsAsync([f.authenticatedUser()])
+        f.USERACCOUNTS[accountData[0].name] = accountData[0]
+      }
       newComment = $(f.createCommentTemplate(f.USERACCOUNTS, commentdata, false, false, guest, guestReply))
       let inputArea = $('.sc-comment__container')
       inputArea.fadeOut(400, () => inputArea.remove())


### PR DESCRIPTION
lukestokes mentioned he had an error when adding a comment. (https://steemit.com/utopian-io/@lukestokes/re-sambillingham-finally-comments-moderate-comment-threads-hide-delete-20180525t175627724z)

```
Uncaught TypeError: Cannot read property 'reputation' of undefined
    at Object.createCommentTemplate (thread.js:607)
    at Object.appendSuccessfulComment (thread.js:357)
    at Object.$.post [as success] (thread.js:347)
    at i (jquery-3.2.1.min.js:2)
    at Object.fireWith [as resolveWith] (jquery-3.2.1.min.js:2)
    at A (jquery-3.2.1.min.js:4)
    at XMLHttpRequest.<anonymous> (jquery-3.2.1.min.js:4)
```


Turned out USERACCOUNTS has no reference if the commenter is new, when creating template after AJAX success it errors. I had not noticed as I test on threads with my account which has already commented so the userdata is loaded in the thread. 