### PR TITLE
Feature Custom Beneficiaries For Comments

### DIFF
--- a/modules/steemconnect.js
+++ b/modules/steemconnect.js
@@ -6,7 +6,7 @@ const Token = require('../models/token')
 let steem = steemconnect2.Initialize({
     app: config.auth.client_id,
     callbackURL: config.auth.redirect_uri,
-    scope: ['login','vote', 'comment']
+    scope: ['login','vote', 'comment', 'comment_options']
 });
 
 let getRefreshToken = (code) => {

--- a/routes/index.js
+++ b/routes/index.js
@@ -81,7 +81,37 @@ router.post('/comment', util.isAuthorized, (req, res) => {
     let body = req.body.message
     let parentAuthor = req.body.parentAuthor
     let parentPermlink = req.body.parentPermlink
-    steem.comment(parentAuthor, parentPermlink, author, permlink, title, body, { app: 'finally.app' }, (err, steemResponse) => {
+
+    let commentParams = {
+      parent_author: parentAuthor,
+      parent_permlink: parentPermlink,
+      author: author,
+      permlink: permlink,
+      title: title,
+      body: body,
+      json_metadata : JSON.stringify({ app: 'finally.app' })
+    }
+    let beneficiaries = [];
+    beneficiaries.push({
+      account: 'finallycomments',
+      weight: 100*10
+    });
+    let commentOptionsParams = {
+      author: author,
+      permlink: permlink,
+      max_accepted_payout: '100000.000 SBD',
+      percent_steem_dollars: 10000,
+      allow_votes: true,
+      allow_curation_rewards: true,
+      extensions: [
+        [0, {
+          beneficiaries: beneficiaries
+        }]
+      ]
+    }
+
+    let operations = [['comment', commentParams], ['comment_options', commentOptionsParams]]
+    steem.broadcast(operations, (err, steemResponse) => {
       if (err) {
         res.json({ error: err.error_description })
       } else {

--- a/routes/index.js
+++ b/routes/index.js
@@ -81,6 +81,8 @@ router.post('/comment', util.isAuthorized, (req, res) => {
     let body = req.body.message
     let parentAuthor = req.body.parentAuthor
     let parentPermlink = req.body.parentPermlink
+    let beneficiary = req.body.beneficiary
+    let beneficiaryWeight = parseInt(req.body.beneficiaryWeight) > 40 ? 40 : parseInt(req.body.beneficiaryWeight)
 
     let commentParams = {
       parent_author: parentAuthor,
@@ -93,8 +95,8 @@ router.post('/comment', util.isAuthorized, (req, res) => {
     }
     let beneficiaries = [];
     beneficiaries.push({
-      account: 'finallycomments',
-      weight: 100*10
+      account: beneficiary,
+      weight: 100*beneficiaryWeight
     });
     let commentOptionsParams = {
       author: author,

--- a/src/js/default.js
+++ b/src/js/default.js
@@ -141,9 +141,17 @@ let app = {
       $('.overlay').addClass('--is-active')
     })
 
-    $('.generate-embded').on('click', () => {
+    $('.generate-embded').on('click', (e) => {
+      let controller = $(e.currentTarget).data('controller')
       let permlink = app.linkToPermlink( $('.generate-url').val() )
-      let controls = { values: true, rep: true, profile: true, generated: false }
+      let controls = {
+        values: $(`.${controller} *[data-value="votes"]`).is(':checked'),
+        rep: $(`.${controller} *[data-value="reputation"]`).is(':checked'),
+        profile: $(`.${controller} *[data-value="profile"]`).is(':checked'),
+        beneficiary: $(`.${controller} *[data-value="beneficiary"]`).is(':checked'),
+        beneficiaryUsername: $(`.${controller} *[data-value="beneficiary-username"]`).val(),
+        beneficiaryPercentage: $(`.${controller} *[data-value="beneficiary-percentage"]`).val()
+      }
       if (permlink) app.dashboadLoadEmbed(permlink, controls)
     })
 

--- a/src/js/default.js
+++ b/src/js/default.js
@@ -128,12 +128,14 @@ let app = {
     $('.load-more-posts').on('click', (e) => {
       app.dashboardLoadPosts(true)
     })
+
     $('.dashboard').on('click', '.load-embed', (e) => {
       let permlink = $(e.currentTarget).data('permlink')
       let controls = {
          values: true, rep: true, profile: true,
-         generated: $(e.currentTarget).data('generated') ? true : false }
-      console.log(controls)
+         generated: $(e.currentTarget).data('generated') ? true : false,
+         beneficiary: false }
+
       app.dashboadLoadEmbed(permlink, controls)
       $('.overlay').data('permlink', permlink)
       $('.overlay').addClass('--is-active')
@@ -156,7 +158,10 @@ let app = {
       let controls = {
         values: $(`.${controller} *[data-value="votes"]`).is(':checked'),
         rep: $(`.${controller} *[data-value="reputation"]`).is(':checked'),
-        profile: $(`.${controller} *[data-value="profile"]`).is(':checked')
+        profile: $(`.${controller} *[data-value="profile"]`).is(':checked'),
+        beneficiary: $(`.${controller} *[data-value="beneficiary"]`).is(':checked'),
+        beneficiaryUsername: $(`.${controller} *[data-value="beneficiary-username"]`).val(),
+        beneficiaryPercentage: $(`.${controller} *[data-value="beneficiary-percentage"]`).val()
       }
       console.log(controls)
       app.dashboadLoadEmbed(permlink, controls)
@@ -178,14 +183,17 @@ let app = {
     return `/${cat}/${author}/${slug}`
   },
   dashboadLoadEmbed: (permlink, controls) => {
+    console.log(controls)
     let id = `    data-id="https://steemit.com${permlink}"\n`
     let rep = controls.rep ? '    data-reputation="true"\n' :''
     let values = controls.values ? '    data-values="true"\n' :''
     let profile = controls.profile ? '    data-profile="true"\n' :''
     let generated = controls.generated ? '    data-generated="true">\n' : '    data-generated="false">\n'
+    let beneficiary = controls.beneficiary ? `    data-beneficiary="${controls.beneficiaryUsername}">\n` : ''
+    let beneficiaryWeight = controls.beneficiary ? `    data-beneficiaryWeight="${controls.beneficiaryPercentage}">\n` : ''
     let embedTemplate = `
 <section class="finally-comments"
-${id}${rep}${values}${profile}${generated}</section>
+${id}${rep}${values}${profile}${generated}${beneficiary}${beneficiaryWeight}</section>
 <script src="https://finallycomments.com/js/finally.min.js"></script>
     `
     $('.embed-code').empty()

--- a/src/js/default.js
+++ b/src/js/default.js
@@ -53,6 +53,8 @@ let app = {
     data-values="true"\n
     data-profile="true"\n
     data-generated="false"\n
+    beneficiary=""\n
+    beneficiaryWeight="0"\n
 </section>\n
 <script src="https://finallycomments.com/js/finally.min.js"></script>`
     $('.strip__code').text(codeBlock)

--- a/src/js/thread.js
+++ b/src/js/thread.js
@@ -340,7 +340,6 @@ const f = {
         $(parentElement).find('.sc-comment__btn').text('Posting... ')
         $(parentElement).find('.sc-comment__btn').append('<img src="/img/loader.gif">')
       }
-
       $.post({
         url: `/comment`,
         dataType: 'json',

--- a/src/js/thread.js
+++ b/src/js/thread.js
@@ -41,7 +41,8 @@ const f = {
       f.OPTIONS.values = data.values === 'false' ? false : true
       f.OPTIONS.profile = data.profile === 'false' ? false : true
       f.OPTIONS.generated = data.generated === 'false' ? false : true
-      console.log(f.OPTIONS)
+      f.OPTIONS.beneficiary = data.beneficiary || false
+      f.OPTIONS.beneficiaryWeight = parseInt(data.beneficiaryWeight) || 0
     },
     frameLoad: (event) => {
       if (event.data.message == 'finally-frame-load'){
@@ -347,7 +348,9 @@ const f = {
           parentAuthor: parentAuthor,
           parentPermlink: parentPermlink,
           message: message,
-          parentTitle: parentTitle
+          parentTitle: parentTitle,
+          beneficiary: f.OPTIONS.beneficiary,
+          beneficiaryWeight: parseInt(f.OPTIONS.beneficiaryWeight)
         }
       }, (response) => {
         if (response.error) {

--- a/src/scss/views/dashboard.scss
+++ b/src/scss/views/dashboard.scss
@@ -70,3 +70,9 @@ label.checkbox span {
   padding: 0;
   margin: 0;
 }
+
+
+.embed-control.input {
+  max-width: 120px;
+  margin-right:15px;
+}

--- a/views/dashboard.pug
+++ b/views/dashboard.pug
@@ -83,7 +83,9 @@ block content
               |   data-values="true"
               |   data-profile="true"
               |   data-generated="true"
-              |   data-api="true">
+              |   data-api="true"
+              |   data-beneficiary=""
+              |   data-beneficiaryWeight="0">
               = '</section>'
               |
               |

--- a/views/dashboard.pug
+++ b/views/dashboard.pug
@@ -27,7 +27,7 @@ block content
             .control
               input.input.generate-url(placeholder="url")
             .control
-              a.button.is-primary.generate-embded(type="text") Create
+              a.button.is-primary.generate-embded(type="text" data-controller="generator-controls") Create
         .generator-controls
           .field
             .control
@@ -40,6 +40,11 @@ block content
               label.checkbox
                 input.embed-control(type="checkbox" data-controller="generator-controls" data-value="profile" checked)
                 span Show User Profile
+              label.checkbox
+                input.embed-control(type="checkbox" data-controller="generator-controls" data-value="beneficiary")
+                span Add Beneficiary (max 40%)
+                input.embed-control.input.is-small(type="text" data-controller="generator-controls" data-value="beneficiary-username" placeholder="username")
+                input.embed-control.input.is-small(type="number" data-controller="generator-controls" data-value="beneficiary-percentage" placeholder="percentage")
         pre
           code.embed-code.language-html
 

--- a/views/dashboard.pug
+++ b/views/dashboard.pug
@@ -139,5 +139,10 @@ block content
               label.checkbox
                 input.embed-control(type="checkbox" data-controller="overlay" data-value="profile" checked)
                 span Show User Profile
+              label.checkbox
+                input.embed-control(type="checkbox" data-controller="overlay" data-value="beneficiary")
+                span Add Beneficiary (max 40%)
+                input.embed-control.input.is-small(type="text" data-controller="overlay" data-value="beneficiary-username" placeholder="username")
+                input.embed-control.input.is-small(type="number" data-controller="overlay" data-value="beneficiary-percentage" placeholder="percentage")
           pre
             code.embed-code.language-html


### PR DESCRIPTION
Add the functionality for setting beneficiaries rewards for comments submitted through Finally. The owner or user who creates the embed can set a single Beneficiary and up to 40%. These are added to individual comments are are created under that thread.

Backend support added. 
Generator + auto loaded embed now include inputs for beneficiary

e.g -
![screen shot 2018-07-01 at 12 54 32](https://user-images.githubusercontent.com/34964560/42134158-ef30acc6-7d2d-11e8-8bb0-761ff0c5f14a.png)


