### PR TITLE
Feature custom thread beneficiary

### DIFF
--- a/controllers/custom-thread.js
+++ b/controllers/custom-thread.js
@@ -1,0 +1,39 @@
+const Thread = require('../models/thread')
+const Domain = require('../models/domain')
+const { URL } = require('url');
+
+module.exports.checkAndGenerate = async (req, res) => {
+  let username = req.params.username
+  let slug = req.params.slug
+  let sluglink = `finally-${slug}`
+  let thread;
+  try { thread = await Thread.findBySlugAndUser(sluglink, username) } catch(error){console.log(error)}
+  if(thread.result){
+    res.redirect(`/thread/finallycomments/@${username}/${sluglink}`)
+  } else {
+    let referer = new URL(req.headers.referer)
+    let domains = await Domain.findOne(username)
+    if (domains.list.indexOf(referer.host) > -1 ){
+      let newToken
+      try { newToken = await getAccessFromRefresh(username) }
+      catch(error){console.log(error)}
+      steem.setAccessToken(newToken.access_token);
+      const FINALLY_AUTHOR = 'finallycomments'
+      const FINALLY_PERMLINK = 'finally-comments-thread'
+      let author = username
+      let permlink = `finally-${slug}`
+      let title = `${username}: Finally Thread`
+      let body = `${username} : This comment is a thread for the Finally Comments System. Visit https://finallycomments.com for more info.`
+      let parentAuthor = FINALLY_AUTHOR
+      let parentPermlink = FINALLY_PERMLINK
+      steem.comment(parentAuthor, parentPermlink, author, permlink, title, body, { app: 'finally.app' }, async (err, steemResponse) => {
+        if (err) { console.log(err); res.redirect('/404');
+        } else {
+          let newThread = { author: author, slug: permlink, title: title }
+          let response = await Thread.insert(newThread)
+          res.redirect(`/thread/finallycomments/@${username}/${permlink}`)
+        }
+      });
+    } else { res.redirect('/404') }
+  }
+}

--- a/controllers/custom-thread.js
+++ b/controllers/custom-thread.js
@@ -11,6 +11,7 @@ module.exports.checkAndGenerate = async (req, res) => {
   if(thread.result){
     res.redirect(`/thread/finallycomments/@${username}/${sluglink}`)
   } else {
+    if(req.headers.referer === undefined) res.redirect('/404')
     let referer = new URL(req.headers.referer)
     let domains = await Domain.findOne(username)
     if (domains.list.indexOf(referer.host) > -1 ){

--- a/controllers/custom-thread.js
+++ b/controllers/custom-thread.js
@@ -1,6 +1,26 @@
 const Thread = require('../models/thread')
 const Domain = require('../models/domain')
+const { steem, getAccessFromRefresh } = require('../modules/steemconnect')
 const { URL } = require('url');
+const FINALLY_AUTHOR = 'finallycomments'
+const FINALLY_PERMLINK = 'finally-comments-thread'
+
+async function createThread(username) {
+  let newToken;
+  try { newToken = await getAccessFromRefresh(username) }
+  catch(error){console.log(error)}
+  steem.setAccessToken(newToken.access_token);
+  let permlink = `finally-${slug}`
+  let title = `${username}: Finally Thread`
+  let body = `${username} : This comment is a thread for the Finally Comments System. Visit https://finallycomments.com for more info.`
+  steem.comment(FINALLY_AUTHOR, FINALLY_PERMLINK, username, permlink, title, body, { app: 'finally.app' }, async (err, steemResponse) => {
+    if (err) { console.log(err); res.redirect('/404');
+    } else {
+      await Thread.insert({ author: author, slug: permlink, title: title })
+      res.redirect(`/thread/finallycomments/@${username}/${permlink}`)
+    }
+  });
+}
 
 module.exports.checkAndGenerate = async (req, res) => {
   let username = req.params.username
@@ -14,27 +34,8 @@ module.exports.checkAndGenerate = async (req, res) => {
     if(req.headers.referer === undefined) res.redirect('/404')
     let referer = new URL(req.headers.referer)
     let domains = await Domain.findOne(username)
-    if (domains.list.indexOf(referer.host) > -1 ){
-      let newToken
-      try { newToken = await getAccessFromRefresh(username) }
-      catch(error){console.log(error)}
-      steem.setAccessToken(newToken.access_token);
-      const FINALLY_AUTHOR = 'finallycomments'
-      const FINALLY_PERMLINK = 'finally-comments-thread'
-      let author = username
-      let permlink = `finally-${slug}`
-      let title = `${username}: Finally Thread`
-      let body = `${username} : This comment is a thread for the Finally Comments System. Visit https://finallycomments.com for more info.`
-      let parentAuthor = FINALLY_AUTHOR
-      let parentPermlink = FINALLY_PERMLINK
-      steem.comment(parentAuthor, parentPermlink, author, permlink, title, body, { app: 'finally.app' }, async (err, steemResponse) => {
-        if (err) { console.log(err); res.redirect('/404');
-        } else {
-          let newThread = { author: author, slug: permlink, title: title }
-          let response = await Thread.insert(newThread)
-          res.redirect(`/thread/finallycomments/@${username}/${permlink}`)
-        }
-      });
+    if (domains.list.indexOf(referer.host) > -1 ) {
+      createThread(username)
     } else { res.redirect('/404') }
   }
 }

--- a/routes/index.js
+++ b/routes/index.js
@@ -190,9 +190,10 @@ router.post('/guest-reply-comments', async (req, res) => {
 });
 
 
-router.get('/api/thread/:username/:slug', cors(), async (req, res, next) => {
+router.get('/api/thread/:username/:slug/:beneficiary?/:bweight?', cors(), async (req, res, next) => {
   CustomThreadController.checkAndGenerate(req, res)
 });
+
 
 router.post('/new-thread', util.isAuthorized, (req, res) => {
   const FINALLY_AUTHOR = 'finallycomments'

--- a/routes/index.js
+++ b/routes/index.js
@@ -200,10 +200,8 @@ router.get('/api/thread/:username/:slug', cors(), async (req, res, next) => {
     res.redirect(`/thread/finallycomments/@${username}/${sluglink}`)
   } else {
     let referer = new URL(req.headers.referer)
-    console.log('REFERER', referer)
     let domains = await Domain.findOne(username)
-
-    if (referer.host){
+    if (domains.list.indexOf(referer.host) > -1 ){
       let newToken
       try { newToken = await getAccessFromRefresh(username) }
       catch(error){console.log(error)}

--- a/src/js/default.js
+++ b/src/js/default.js
@@ -182,7 +182,9 @@ let app = {
     $('.new-thread').on('click', () => {
       $('.new-thread').addClass('is-loading')
       let title = $('.new-thread-title').val().trim()
-      app.dashboardNewThread(title)
+      let beneficiary = $('.new-thread-beneficiary').val().trim()
+      let beneficiaryWeight = parseInt($('.new-thread-beneficiary-weight').val())
+      app.dashboardNewThread(title, beneficiary, beneficiaryWeight)
     })
   },
   linkToPermlink(link){
@@ -209,11 +211,11 @@ ${id}${rep}${values}${profile}${generated}${beneficiary}${beneficiaryWeight}</se
     $('.embed-code').empty()
     $('.embed-code').text(embedTemplate)
   },
-  dashboardNewThread:(title) => {
+  dashboardNewThread:(title, beneficiary, beneficiaryWeight) => {
       $.post({
         url: `/new-thread`,
         dataType: 'json',
-        data: { title : title }
+        data: { title, beneficiary, beneficiaryWeight }
       }, (response) => {
         console.log(response)
         $('.new-thread').removeClass('is-loading')

--- a/views/dashboard.pug
+++ b/views/dashboard.pug
@@ -97,6 +97,9 @@ block content
         h3.title.is-3 Custom Threads
           .new-thread__container.field.has-addons
             .control
+              input.input.new-thread-title.embed-control(type="text" placeholder="Beneficiary" class="new-thread-beneficiary")
+              input.input.new-thread-title.embed-control(type="number" placeholder="Percentage" class="new-thread-beneficiary-weight")
+            .control
               input.input.new-thread-title(type="text" placeholder="Title")
             .control
               a.button.is-primary.new-thread New Thread


### PR DESCRIPTION
Adds support for adding Beneficiary to the top-level post that controls custom threads. The account creating the custom thread is already receiving all rewards but Beneficiary allows this to be shared with a 2nd account if needed. 

UI added to custom thread creation in dashboard

